### PR TITLE
[WIP] Add service class boilerplate generation tools

### DIFF
--- a/tools/service-generator/requirements.txt
+++ b/tools/service-generator/requirements.txt
@@ -1,0 +1,2 @@
+cogapp
+inflection

--- a/tools/service-generator/templates/service/ServiceTemplate.cpp
+++ b/tools/service-generator/templates/service/ServiceTemplate.cpp
@@ -1,0 +1,124 @@
+/*
+ * Mbed-OS Microcontroller Library
+ *
+ * [[[cog
+ *    import cog, datetime, json, inflection
+ *    with open(spec_file, 'r') as f:
+ *       spec = json.loads(f.read())
+ *       # Save this for later in the global dictionary
+ *       globals()['spec'] = spec
+ *       cog.outl(f' * Copyright (c) { datetime.date.today().year } { spec["copyright-org"] }')
+ * ]]]
+ * [[[end]]]
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ *
+ * [[[cog
+ *    cog.outl(f' * The basis for this file was automatically generated.\n'
+ *             f' * Generation tools Copyright (c) { datetime.date.today().year } Embedded Planet, Inc')
+ * ]]]
+ * [[[end]]]
+ *
+ */
+
+//[[[cog
+//chars = spec["service"]["characteristics"]
+//s_name = spec["service"]["name"]
+//cog.outl(f'#include "{ s_name }.h"\n')
+//has_custom = False
+//longest_name_len = 0
+//# Append the service name and UUID to the beginning of the list
+//# This ensures the padding logic below works for the service UUID as well
+//chars.insert(0, {'name': 'Base', 'uuid': spec["service"]["uuid"]})
+//for c in chars:
+//   if len(c['name']) > longest_name_len:
+//      longest_name_len = len(c['name'])
+//   if len(c['uuid']) > 6:
+//      has_custom = True
+//
+//if has_custom:
+//   cog.outl('namespace uuids { ')
+//   cog.outl(f'namespace { s_name } {{')
+//   # Pad to the longest characteristic name, round up to nearest 4 for tab alignment
+//   prefix = '    extern const char '
+//   postfix = 'UUID[]'
+//   pad_len = ((((longest_name_len + len(prefix) + len(postfix)) // 4) + 1) * 4) - 1
+//   for c in chars:
+//      cog.outl(f'{{:<{pad_len}}} = "{{}}";'.format((prefix + c['name'] + postfix),
+//                                             c['uuid'].upper()))
+//   cog.outl('}')
+//   cog.outl('}')
+//# Remove the service name from chars
+//chars.pop(0)
+//]]]
+//[[[end]]]
+
+#if BLE_FEATURE_GATT_SERVER
+
+//[[[cog
+//# Generate the constructor and initializer list
+//cog.outl(f'{ s_name }::{ s_name }(BLE &ble) :\n    _ble(ble),')
+//for i, c in enumerate(chars):
+//   c_name = inflection.underscore(c["name"])
+//   cog.outl(f'    _{ c_name }_char(uuids::{ s_name }::{ c["name"] }UUID,')
+//   if c["has-variable-length"]:
+//      cog.outl(f'        (uint8_t*) &_{ c_name }, { c["length"] }, { c["max-length"] },')
+//   else:
+//      cog.outl(f'        (uint8_t*) &_{ c_name }, sizeof(_{ c_name }), sizeof(_{ c_name }),')
+//   for j, p in enumerate(c["properties"]):
+//      cog.out('        ')
+//      if not j:
+//         cog.out('(')
+//      else:
+//         cog.out(' ')
+//      cog.out(f'GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_{ p }')
+//      if j == (len(c["properties"])-1):
+//         cog.outl('),')
+//      else:
+//         cog.outl(' |')
+//   cog.outl('        nullptr, 0, false),')
+//   cog.out(f'    _{ c_name }(0)')
+//   if i != (len(chars) - 1):
+//      cog.outl(',')
+//   else:
+//      cog.outl(' {')
+//cog.outl('}')
+//
+//# Destructor
+//cog.outl(f'\n{ s_name }::~{ s_name }() {{ \n}}\n')
+//
+//# Initialization
+//cog.outl(f'void { s_name }::init() {{\n')
+//cog.outl('    GattCharacteristic *charTable[] = {')
+//for c in chars:
+//   c_name = inflection.underscore(c["name"])
+//   cog.out(f'                &_{ c_name }_char')
+//   if c != chars[-1]:
+//      cog.outl(',')
+//   else:
+//      cog.out('\n')
+//cog.outl('    };\n')
+//cog.outl(f'    GattService service(uuids::{ s_name }::BaseUUID, charTable, sizeof(charTable));')
+//]]]
+//[[[end]]]
+
+    ble_error_t error = _ble.gattServer().addService(service);
+    if(error != BLE_ERROR_NONE) {
+        /* Handle error */
+    }
+}
+
+#endif /* BLE_FEATURE_GATT_SERVER */
+

--- a/tools/service-generator/templates/service/ServiceTemplate.h
+++ b/tools/service-generator/templates/service/ServiceTemplate.h
@@ -1,0 +1,94 @@
+/*
+ * Mbed-OS Microcontroller Library
+ *
+ * [[[cog
+ *    import cog, datetime, json, inflection
+ *    with open(spec_file, 'r') as f:
+ *       spec = json.loads(f.read())
+ *       # Save this for later in the global dictionary
+ *       globals()['spec'] = spec
+ *       cog.outl(f' * Copyright (c) { datetime.date.today().year } { spec["copyright-org"] }')
+ * ]]]
+ * [[[end]]]
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ *
+ * [[[cog
+ *    cog.outl(f' * The basis for this file was automatically generated.\n'
+ *             f' * Generation tools Copyright (c) { datetime.date.today().year } Embedded Planet, Inc')
+ * ]]]
+ * [[[end]]]
+ *
+ */
+
+//[[[cog
+//h_guard = f'{ inflection.underscore(spec["service"]["name"]).upper() }_H'
+//cog.outl(f'#ifndef { h_guard }')
+//cog.outl(f'#define { h_guard }')
+//globals()['h_guard'] = h_guard
+//]]]
+//[[[end]]]
+
+//[[[cog
+//chars = spec["service"]["characteristics"]
+//has_custom = False
+//# Temporarily append the service name and UUID to the beginning of the list
+//chars.insert(0, {'name': 'Base', 'uuid': spec["service"]["uuid"]})
+//for c in chars:
+//   if len(c['uuid']) > 6:
+//      has_custom = True
+//      break
+//
+//if has_custom:
+//   cog.outl('namespace uuids { ')
+//   cog.outl(f'namespace { spec["service"]["name"] } {{')
+//   prefix = '    extern const char '
+//   postfix = 'UUID[];'
+//   for c in chars:
+//      cog.outl(prefix + c['name'] + postfix)
+//   cog.outl('}}')
+//# Remove the service name from chars
+//chars.pop(0)
+//]]]
+//[[[end]]]
+
+#if BLE_FEATURE_GATT_SERVER
+
+#include "ble/BLE.h"
+#include "ble/Gap.h"
+#include "ble/gatt/GattCharacteristic.h"
+
+//[[[cog
+//cog.outl(f'class { spec["service"]["name"] } {{')
+//cog.outl('\npublic:\n')
+//cog.outl(f'    { spec["service"]["name"] }(BLE &ble);\n')
+//cog.outl(f'    ~{ spec["service"]["name"] }();\n')
+//cog.outl(f'    void init();\n')
+//cog.outl('protected:\n')
+//cog.outl('    BLE &_ble\n')
+//for c in spec["service"]["characteristics"]:
+//   cog.outl(f'    GattCharacteristic _{ inflection.underscore(c["name"]) }_char;')
+//   cog.outl(f'    { c["type"] } _{ inflection.underscore(c["name"]) };\n')
+//]]]
+//[[[end]]]
+
+};
+
+#endif /* BLE_FEATURE_GATT_SERVER */
+
+//[[[cog
+//cog.outl(f'#endif /* { h_guard } */')
+//]]]
+//[[[end]]]

--- a/tools/service-generator/templates/service/service-definition-template.json
+++ b/tools/service-generator/templates/service/service-definition-template.json
@@ -1,0 +1,27 @@
+{
+    "copyright-org": "Embedded Planet, Inc",
+    "service": {
+        "name": "ServiceName",
+        "uuid": "String (custom) or 16-bit int (standardized)",
+        "characteristics": [
+            {
+                "name": "CharacteristicName",
+                "uuid": "String (custom) or 16-bit int (standardized)",
+                "properties": ["BROADCAST",
+                               "READ",
+                               "WRITE_WITHOUT_RESPONSE",
+                               "WRITE",
+                               "NOTIFY",
+                               "INDICATE",
+                               "AUTHENTICATED_SIGNED_WRITES",
+                               "EXTENDED_PROPERTIES"],
+                "type": "typename exactly as written in C/C++",
+                "has-variable-length": true,
+                "length": null,
+                "max-length": null,
+                "security-requirements": "NONE"
+            }
+        ]
+    }
+}
+            


### PR DESCRIPTION
This commit introduces an experimental boilerplate generator using the python library cog. The associated cog templates will product a basic .h and .cpp file for a service specified by the given .json file. A template service definition json file is also included.

Usage:
`cog -d D spec_file=example.json ExampleService.h ServiceTemplate.h`
`cog -d D spec_file=example.json ExampleService.cpp ServiceTemplate.cpp`

Example output has been attached as a zip. The zip contains an example `.json` service specification along with the generated ExampleService.h and ExampleService.cpp

[ExampleService.zip](https://github.com/ARMmbed/mbed-os-experimental-ble-services/files/5716879/ExampleService.zip)

