### PR TITLE
Add return to init

### DIFF
--- a/services/LinkLoss/include/ble-service-link-loss/LinkLossService.h
+++ b/services/LinkLoss/include/ble-service-link-loss/LinkLossService.h
@@ -105,8 +105,10 @@ public:
      *
      * Set the onDataWritten() function as the write authorization callback for the alert level characteristic.
      * Add the link loss service to the BLE device and chain of GAP event handlers.
+     *
+     * @return BLE_ERROR_NONE if the initialisation process completed successfully.
      */
-    void init();
+    ble_error_t init();
 
     /**
      * Set event handler

--- a/services/LinkLoss/source/LinkLossService.cpp
+++ b/services/LinkLoss/source/LinkLossService.cpp
@@ -32,7 +32,7 @@ LinkLossService::~LinkLossService()
     _event_queue.cancel(_event_queue_handle);
 }
 
-void LinkLossService::init()
+ble_error_t LinkLossService::init()
 {
     GattCharacteristic *charTable[] = { &_alert_level_char };
     GattService         linkLossService(GattService::UUID_LINK_LOSS_SERVICE, charTable, 1);
@@ -44,6 +44,8 @@ void LinkLossService::init()
     if (error == BLE_ERROR_NONE) {
         _chainable_gap_event_handler.addEventHandler(this);
     }
+
+    return error;
 }
 
 void LinkLossService::set_event_handler(EventHandler* handler)


### PR DESCRIPTION
In the Link Loss Service, the `init` function should propagate the error returned by the Gatt Server.