### PR TITLE
Use OUT_OF_RANGE const. for write auth. reply

### DIFF
--- a/services/LinkLoss/source/LinkLossService.cpp
+++ b/services/LinkLoss/source/LinkLossService.cpp
@@ -107,8 +107,7 @@ void LinkLossService::onDataWritten(GattWriteAuthCallbackParams *write_request)
     if (level <= (uint8_t)(AlertLevel::HIGH_ALERT)) {
         set_alert_level((AlertLevel) level);
     } else {
-        // The alert level is out of range
-        write_request->authorizationReply = static_cast<GattAuthCallbackReply_t>(0xFF);
+        write_request->authorizationReply = GattAuthCallbackReply_t::AUTH_CALLBACK_REPLY_ATTERR_OUT_OF_RANGE;
     }
 }
 


### PR DESCRIPTION
In the `onDataWritten` function of the Link Loss Service, the `AUTH_CALLBACK_REPLY_ATTERR_OUT_OF_RANGE` constant can be used instead of casting the literal `0xFF` to `GattAuthCallbackReply_t`.