### PR TITLE
Auto-activate virtual environment in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get install -y locales && localedef -i en_US -c -f UTF-8 -A /usr/share/l
 RUN apt-get -fy install vim sudo bash-completion build-essential gdb docker.io
 RUN apt-get update && apt-get install -y valgrind gcovr
 RUN pip3 install virtualenv
-RUN pip3 install mbed-tools --upgrade
 
 # Create the user
 RUN groupadd -g $USER_GID $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,6 +22,9 @@ RUN useradd -s /bin/bash -u $USER_UID -g $USER_GID -G docker -m $USERNAME
 RUN echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME
 RUN chmod 0440 /etc/sudoers.d/$USERNAME
 
+# Give user access to toolchan
+RUN chmod 755 /root
+
 # ********************************************************
 # * Anything else you want to do like clean up goes here *
 # ********************************************************

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # ARG VARIANT=""
-FROM mbedos/mbed-os-env-cmake
+FROM mbedos/mbed-os-env
 
 # This Dockerfile contains things useful for an interactive development environment
 ARG USERNAME=vscode
@@ -13,6 +13,9 @@ ENV LC_ALL en_US.UTF-8
 RUN apt-get update
 RUN apt-get install -y locales && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 RUN apt-get -fy install vim sudo bash-completion build-essential gdb docker.io
+RUN apt-get update && apt-get install -y valgrind gcovr
+RUN pip3 install virtualenv
+RUN pip3 install mbed-tools --upgrade
 
 # Create the user
 RUN groupadd -g $USER_GID $USERNAME

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
 
 	// Set *default* container specific settings.json values on container create.
 	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash"
+		"terminal.integrated.shell.linux": "/bin/bash",
+		"terminal.integrated.shellArgs.linux": ["--init-file", "init.sh"]
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -17,7 +17,6 @@ jobs:
           run: |
             apt-get update && apt-get install -y valgrind gcovr
             pip3 install virtualenv
-            pip3 install mbed-tools --upgrade
 
         - name: Run unit tests
           run: ./tests/unittests.sh
@@ -40,7 +39,6 @@ jobs:
         run: |
           apt-get update && apt-get install -y valgrind gcovr
           pip3 install virtualenv
-          pip3 install mbed-tools --upgrade
 
       - name: Run integration tests
         run: |

--- a/activate.sh
+++ b/activate.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 # Enter repository root
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -57,3 +57,6 @@ pip install -r tests/mbed-os/requirements.txt
 
 # Install testing requirements
 pip install -r tests/TESTS/requirements.txt
+
+# Install cli and tools
+pip install --upgrade mbed-cli mbed-tools

--- a/init.sh
+++ b/init.sh
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 # Reload .bashrc settings
 source ~/.bashrc
 

--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Reload .bashrc settings
+source ~/.bashrc
+
+# Activate virtual environment
+source activate.sh


### PR DESCRIPTION
This PR enables auto-activation of the Python virtual environment inside the devcontainer.

Note: #42 should merge to `github-ci` first.