### PR TITLE
Update BLE testing helpers to non-blocking

### DIFF
--- a/tests/TESTS/DeviceInformation/host/test_device_information.py
+++ b/tests/TESTS/DeviceInformation/host/test_device_information.py
@@ -14,13 +14,13 @@
 # limitations under the License
 
 import pytest
-import platform
 
 from common.fixtures import BoardAllocator, ClientAllocator
 
+
 @pytest.fixture(scope="function")
-def board(board_allocator: BoardAllocator):
-    board = board_allocator.allocate('DeviceInformation')
+async def board(board_allocator: BoardAllocator):
+    board = await board_allocator.allocate('DeviceInformation')
     yield board
     board_allocator.release(board)
 
@@ -60,6 +60,3 @@ async def test_device_information_service_values(board, client):
         uuid, expected_value = char
         char_value = await client.read_gatt_char(uuid)
         assert char_value == expected_value
-
-
-

--- a/tests/TESTS/common/fixtures.py
+++ b/tests/TESTS/common/fixtures.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import mbed_lstools
+import platform
 import logging
 import pytest
 
@@ -160,7 +161,7 @@ class ClientAllocator:
                     while attempts > 0:
                         try:
                             connected = await self.client.connect()
-                            if connected is True:
+                            if connected:
                                 return self.client
                         except BleakError:
                             pass
@@ -170,12 +171,12 @@ class ClientAllocator:
 
     async def release(self, client: BleakClient) -> None:
         if self.client == client and self.client is not None:
-            if await client.is_connected():
+            if self.client.is_connected:
                 attempts = 5
                 while attempts > 0:
                     try:
-                        disconnected = await client.disconnect()
-                        if disconnected is True:
+                        disconnected = await self.client.disconnect()
+                        if disconnected:
                             self.client = None
                             return
                     except BleakError:

--- a/tests/TESTS/common/serial_device.py
+++ b/tests/TESTS/common/serial_device.py
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
 import logging
 import re
 import threading
 
-from queue import Empty
+from queue   import Empty
 from .device import Device
 
-log = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 def strip_escape(string_to_escape) -> str:
@@ -54,12 +55,12 @@ class SerialDevice(Device):
         self.serial = serial_connection
         self.run = True
         super(SerialDevice, self).__init__(name)
-        input_thread_name = '<-- {}'.format(self.name)
-        output_thread_name = '--> {}'.format(self.name)
+        ip_thread_name = '<-- {}'.format(self.name)
+        op_thread_name = '--> {}'.format(self.name)
 
-        self.it = threading.Thread(target=self._input_thread, name=input_thread_name)
-        self.ot = threading.Thread(target=self._output_thread, name=output_thread_name)
-        log.info('Starting runner threads for "{}"'.format(self.name))
+        self.it = threading.Thread(target=self._ip_thread, name=ip_thread_name)
+        self.ot = threading.Thread(target=self._op_thread, name=op_thread_name)
+        logger.info('Starting runner threads for "{}"'.format(self.name))
         self.it.start()
         self.ot.start()
 
@@ -74,14 +75,16 @@ class SerialDevice(Device):
         """
         Stop the processing of the serial
         """
-        log.info('Stopping "{}" runner...'.format(self.name))
+        logger.info('Stopping "{}" runner...'.format(self.name))
         self.run = False
         self.it.join()
         self.ot.join()
 
-    def _input_thread(self):
+    def _ip_thread(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         while self.run:
-            line = self.serial.readline()
+            line = loop.run_until_complete(self.serial.readline_async())
             if line:
                 plain_line = strip_escape(line)
                 # Testapp uses \r to print characters to the same line, strip those and return only the last part
@@ -93,23 +96,25 @@ class SerialDevice(Device):
                 try:
                     plain_line = plain_line.decode()
                 except UnicodeDecodeError:
-                    log.warning('{}: Invalid bytes read: {}'.format(self.name, line))
+                    logger.warning('{}: Invalid bytes read: {}'.format(self.name, line))
                     continue
                 plain_line.rstrip()
-                log.info('<--|{}| {}'.format(self.name, plain_line.strip()))
+                logger.info('<--|{}| {}'.format(self.name, plain_line.strip()))
                 self.iq.put(plain_line)
             else:
                 pass
 
-    def _output_thread(self):
+    def _op_thread(self):
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
         while self.run:
             try:
                 line = self.oq.get(timeout=1)
                 if line:
-                    log.info('-->|{}| {}'.format(self.name, line.strip()))
+                    logger.info('-->|{}| {}'.format(self.name, line.strip()))
                     data = line + '\n'
-                    self.serial.write(data.encode('utf8'))
+                    loop.run_until_complete(self.serial.write_async(data.encode('utf8')))
                 else:
-                    log.debug('Nothing sent')
+                    logger.debug('Nothing sent')
             except Empty:
                 pass

--- a/tests/TESTS/requirements.txt
+++ b/tests/TESTS/requirements.txt
@@ -2,7 +2,7 @@ aioserial==1.3.0
 appdirs==1.4.4
 atomicwrites==1.4.0
 attrs==20.3.0
-bleak==0.11.0
+bleak==0.10.0
 certifi==2020.12.5
 chardet==4.0.0
 fasteners==0.16

--- a/tests/TESTS/requirements.txt
+++ b/tests/TESTS/requirements.txt
@@ -1,11 +1,12 @@
+aioserial==1.3.0
 appdirs==1.4.4
 atomicwrites==1.4.0
 attrs==20.3.0
-bleak==0.10.0
+bleak==0.11.0
 certifi==2020.12.5
 chardet==4.0.0
 fasteners==0.16
-importlib-metadata==3.4.0
+importlib-metadata==3.10.0
 iniconfig==1.1.1
 lockfile==0.12.2
 mbed-flasher==0.10.1
@@ -18,8 +19,9 @@ pyparsing==2.4.7
 pytest==6.2.2
 pytest-asyncio==0.14.0
 pythonnet==2.5.2;platform_system=='Windows'
-soupsieve==2.2
+soupsieve==2.2.1
 toml==0.10.2
 typing-extensions==3.7.4.3
+urllib3==1.26.4
 wcwidth==0.2.5
-zipp==3.4.0
+zipp==3.4.1

--- a/tests/TESTS/requirements.txt
+++ b/tests/TESTS/requirements.txt
@@ -2,7 +2,8 @@ aioserial==1.3.0
 appdirs==1.4.4
 atomicwrites==1.4.0
 attrs==20.3.0
-bleak==0.10.0
+bleak==0.11.0;sys_platform == 'darwin'
+bleak==0.10.0;sys_platform != 'darwin'
 certifi==2020.12.5
 chardet==4.0.0
 fasteners==0.16


### PR DESCRIPTION
The integration testing utilities contain slow IO operations that can block the 
event loop, and asyncio code is only effective if the main execution thread 
contains no blocking code. Basically, blocking code is any code that "holds 
up" the event loop, i.e. prevents it from smoothly executing awaitables on the 
loop. For example, placing time.sleep() in an asyncio program is a bad idea 
since it completely halts the main execution thread. 

This PR updates the integration testing utilities to non-blocking. The 
objective is not to completely remove/hide synchronous code because whether a 
function is blocking or not depends very much on its use and execution context. 
Moreover, the process of making code non-blocking often entails running it in a 
background thread, which comes with some cost. This is how the 
wait_for_output() function of the Device class is made non-blocking, and 
aioserial makes extensive use of this approach too.
 
## Reviewers
@pan-
@paul-szczepanek-arm 