### PR TITLE
Fix Windows symbolic links

### DIFF
--- a/scripts/activate.sh
+++ b/scripts/activate.sh
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Repository root
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"/..
+# Enter repository root
+cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 
 # Test if script is running on windows
 windows() {
@@ -23,7 +23,7 @@ windows() {
 
 # Activate virtual environment
 if windows; then
-  source "$ROOT"/tests/TESTS/venv/Scripts/activate
+  source tests/TESTS/venv/Scripts/activate
 else
-  source "$ROOT"/tests/TESTS/venv/bin/activate
+  source tests/TESTS/venv/bin/activate
 fi

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -13,53 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Repository root
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"/.. || exit
+# Enter repository root
+cd "$( dirname "${BASH_SOURCE[0]}" )"/..
 
 # Load symlink script
-source "$ROOT"/scripts/symlink.sh
+source scripts/symlink.sh
 
 # Clone mbed-os
-if [ -d "$ROOT/dependencies/mbed-os" ]
+if [ -d "dependencies/mbed-os" ]
 then
     echo "Using existing mbed-os"
 else
     # git clone https://github.com/ARMmbed/mbed-os.git
     # Use feature branch until merged to master
-    git clone --depth 1 https://github.com/ARMmbed/mbed-os.git -b feature_unittest_refactor "$ROOT"/dependencies/mbed-os
+    git clone --depth 1 https://github.com/ARMmbed/mbed-os.git -b feature_unittest_refactor dependencies/mbed-os
 fi
 
 # Add symlinks
-symlink "$ROOT"/dependencies/mbed-os "$ROOT"/tests/TESTS/DeviceInformation/device/mbed-os
-symlink "$ROOT"/services/DeviceInformation "$ROOT"/tests/TESTS/DeviceInformation/device/DeviceInformation
+symlink dependencies/mbed-os       tests/UNITTESTS/mbed-os
 
-symlink "$ROOT"/dependencies/mbed-os "$ROOT"/tests/UNITTESTS/mbed-os
-symlink "$ROOT"/dependencies/mbed-os "$ROOT"/tests/TESTS/LinkLoss/device/mbed-os
-symlink "$ROOT"/services/LinkLoss "$ROOT"/tests/TESTS/LinkLoss/device/LinkLoss
+symlink dependencies/mbed-os       tests/TESTS/LinkLoss/device/mbed-os
+symlink services/LinkLoss          tests/TESTS/LinkLoss/device/LinkLoss
+
+symlink dependencies/mbed-os       tests/TESTS/DeviceInformation/device/mbed-os
+symlink services/DeviceInformation tests/TESTS/DeviceInformation/device/DeviceInformation
 
 # Create virtual environment
-if [ -d "$ROOT/tests/TESTS/venv" ]
+if [ -d "tests/TESTS/venv" ]
 then
   echo "Using existing virtual environment"
 else
-  mkdir "$ROOT"/tests/TESTS/venv
+  mkdir tests/TESTS/venv
   # On Windows, the Python 3 executable is called 'python'
   if windows; then
-    python  -m virtualenv "$ROOT"/tests/TESTS/venv
+    python  -m virtualenv tests/TESTS/venv
   else
-    python3 -m virtualenv "$ROOT"/tests/TESTS/venv
+    python3 -m virtualenv tests/TESTS/venv
   fi
 fi
 
 # Activate virtual environment
-source "$ROOT"/scripts/activate.sh
+source scripts/activate.sh
 
 # Install mbed-os requirements
-pip install -r "$ROOT"/dependencies/mbed-os/requirements.txt
+pip install -r dependencies/mbed-os/requirements.txt
 
 # Install testing requirements
-pip install -r "$ROOT"/tests/TESTS/requirements.txt
+pip install -r tests/TESTS/requirements.txt
 
 # Install cli and tools
 pip install --upgrade mbed-cli mbed-tools

--- a/tests/TESTS/README.md
+++ b/tests/TESTS/README.md
@@ -36,6 +36,8 @@ The general syntax is:
 symlink <source> <destination>
 ```
 
+On Windows, you can run this in [Git BASH](https://gitforwindows.org/) with admin privileges.
+
 ## Integration testing with pytest
 The [pytest](https://docs.pytest.org/en/stable/) framework is used to write the tests. 
 However, bleak makes extensive use of [coroutine functions](https://docs.python.org/3/library/asyncio-task.html#id1), which are not natively supported by pytest.

--- a/tests/TESTS/build.sh
+++ b/tests/TESTS/build.sh
@@ -30,6 +30,9 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Activate virtual environment
 source ../../scripts/activate.sh
 
+# Restore wd
+cd tests/TESTS
+
 # Parse options
 while getopts "s:t:m:h" opt
 do

--- a/tests/UNITTESTS/build.sh
+++ b/tests/UNITTESTS/build.sh
@@ -21,6 +21,9 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Activate virtual environment
 source ../../scripts/activate.sh
 
+# Restore wd
+cd tests/UNITTESTS
+
 # Build unit tests
 cmake -S . -B cmake_build -GNinja -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE:STRING=xml
 cmake --build cmake_build

--- a/tests/UNITTESTS/run.sh
+++ b/tests/UNITTESTS/run.sh
@@ -21,6 +21,9 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Activate virtual environment
 source ../../scripts/activate.sh
 
+# Restore wd
+cd tests/UNITTESTS
+
 # Run unit tests
 (cd cmake_build; ctest -V)
 (cd cmake_build; ctest -D ExperimentalMemCheck)


### PR DESCRIPTION
Prepending the `ROOT` variable to relative paths produces incorrect absolute paths on Windows:

```shell
The system cannot find the path specified.
```

`cd` into the root repository and use relative paths instead.