### PR TITLE
Add target_compile_definitions to unit testing template

### DIFF
--- a/tests/UNITTESTS/README.md
+++ b/tests/UNITTESTS/README.md
@@ -53,10 +53,11 @@ target_link_libraries(${TEST_NAME}
 )
 
 target_compile_definitions(${TEST_NAME}
-     PUBLIC
-        # CMake does not generate configuration options;
-        # if your service has an mbed_lib.json, you must define the configuration parameters here
-        BLE_FEATURE_GATT_SERVER=1
+    PUBLIC
+        # CMake does not generate config options;
+        # if your service defines config parameters in an mbed_lib.json,
+        # you must also define them here
+        CONFIGURATION_MACRO_NAME=1
 )
 
 add_test(NAME "${TEST_NAME}" COMMAND ${TEST_NAME})

--- a/tests/UNITTESTS/README.md
+++ b/tests/UNITTESTS/README.md
@@ -52,6 +52,13 @@ target_link_libraries(${TEST_NAME}
         gmock_main
 )
 
+target_compile_definitions(${TEST_NAME}
+     PUBLIC
+        # CMake does not generate configuration options;
+        # if your service has an mbed_lib.json, you must define the configuration parameters here
+        BLE_FEATURE_GATT_SERVER=1
+)
+
 add_test(NAME "${TEST_NAME}" COMMAND ${TEST_NAME})
 ```
 

--- a/tests/UNITTESTS/Template/CMakeLists.txt
+++ b/tests/UNITTESTS/Template/CMakeLists.txt
@@ -36,9 +36,10 @@ target_link_libraries(${TEST_NAME}
 
 target_compile_definitions(${TEST_NAME}
     PUBLIC
-        # CMake does not generate configuration options;
-        # if your service has an mbed_lib.json, you must define the configuration parameters here
-        BLE_FEATURE_GATT_SERVER=1
+        # CMake does not generate config. options;
+        # if your service defines config. parameters in an mbed_lib.json,
+        # you must also define them here
+        CONFIGURATION_MACRO_NAME=1
 )
 
 add_test(NAME "${TEST_NAME}" COMMAND ${TEST_NAME})

--- a/tests/UNITTESTS/Template/CMakeLists.txt
+++ b/tests/UNITTESTS/Template/CMakeLists.txt
@@ -34,4 +34,11 @@ target_link_libraries(${TEST_NAME}
         gmock_main
 )
 
+target_compile_definitions(${TEST_NAME}
+    PUBLIC
+        # CMake does not generate configuration options;
+        # if your service has an mbed_lib.json, you must define the configuration parameters here
+        BLE_FEATURE_GATT_SERVER=1
+)
+
 add_test(NAME "${TEST_NAME}" COMMAND ${TEST_NAME})


### PR DESCRIPTION
A good point was raised [here](https://github.com/ARMmbed/mbed-os-experimental-ble-services/issues/46#issuecomment-805834211) about the use of configuration parameters in unit tests. If your service defines configuration parameters in an mbed_lib.json file, you must also define them in your CMakeLists.txt, otherwise the build will fail.

This PR adds a [target_compile_definitions](https://cmake.org/cmake/help/latest/command/target_compile_definitions.html) command to the template and updates the unit testing guide.