### PR TITLE
None client if disconnected in release

### DIFF
--- a/tests/TESTS/common/fixtures.py
+++ b/tests/TESTS/common/fixtures.py
@@ -185,6 +185,7 @@ class ClientAllocator:
                 if platform.system() == "Darwin":
                     await client.connect()
                     await self.release(client)
+            self.client = None
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
**Note**: This is addressed in #48 but that is blocked.

During client allocation, None is returned if the client is not None. 
Therefore, in releasing the client, it should be set to None even if it's 
disconnected to begin with. Otherwise, client test fixtures will yield None if 
the previous test enters tear down in a disconnected state. For example, in the 
following parameterised test, where [alert-level1-High Alert!] fails:

```shell
python -m pytest LinkLoss/host/test_link_loss.py::test_alert_mechanism
```