### PR TITLE
Create mbed-os.lib in bootstrap

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,6 +38,10 @@ symlink services/LinkLoss          tests/TESTS/LinkLoss/device/LinkLoss
 symlink dependencies/mbed-os       tests/TESTS/DeviceInformation/device/mbed-os
 symlink services/DeviceInformation tests/TESTS/DeviceInformation/device/DeviceInformation
 
+# Create mbed-os.lib for CMake builds
+echo "https://github.com/ARMmbed/mbed-os" > tests/TESTS/LinkLoss/device/mbed-os.lib
+echo "https://github.com/ARMmbed/mbed-os" > tests/TESTS/DeviceInformation/device/mbed-os.lib
+
 # Create virtual environment
 if [ -d "tests/TESTS/venv" ]
 then

--- a/tests/TESTS/DeviceInformation/device/mbed-os.lib
+++ b/tests/TESTS/DeviceInformation/device/mbed-os.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-os

--- a/tests/TESTS/LinkLoss/device/mbed-os.lib
+++ b/tests/TESTS/LinkLoss/device/mbed-os.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-os


### PR DESCRIPTION
Mbed CLI and Tools perform recursive `deploy`. So, if your example has an `mbed-os-experimental-ble-services.lib` and you try to deploy, mbed-os will be imported into each test suite. This is slow and pollutes the tree. 

The `mbed-os.lib` are only required for integration tests, so let's create them in bootstrap.